### PR TITLE
fix: binding method call failed in video

### DIFF
--- a/packages/kraken_video_player/CHANGELOG.md
+++ b/packages/kraken_video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+* Fix the binding method can not be called.
+
 ## 1.1.0
 
 * Upgrade to kraken 0.9.1

--- a/packages/kraken_video_player/lib/video_element.dart
+++ b/packages/kraken_video_player/lib/video_element.dart
@@ -230,33 +230,40 @@ class VideoElement extends MediaElement {
   }
 
   @override
-  invokeBindingMethod(String method, List args) {
-    switch (method) {
-      case 'play': return play();
-      case 'pause': return pause();
-      case 'fastSeek': return fastSeek(castToType<num>(args[0]).toDouble());
-      default: return super.invokeBindingMethod(method, args);
-    }
-  }
-
-  @override
   void setBindingProperty(String key, value) {
     switch (key) {
       case 'src': src = castToType<String>(value); break;
       case 'loop': loop = castToType<bool>(value); break;
+      case 'autoplay': autoplay = castToType<bool>(value); break;
       case 'currentTime': currentTime = castToType<num>(value).toInt(); break;
       default: super.setBindingProperty(key, value);
     }
   }
 
+  void _bindingPlay(List args) {
+    play();
+  }
+
+  void _bindingPause(List args) {
+    pause();
+  }
+
+  void _bindingFastSeek(List args) {
+    fastSeek(castToType<double>(args[0]));
+  }
+
   @override
   getBindingProperty(String key) {
     switch (key) {
+      case 'play': return _bindingPlay;
+      case 'pause': return _bindingPause;
+      case 'fastSeek': return _bindingFastSeek;
+      case 'autoplay': return autoplay;
       case 'loop': return loop;
       case 'currentTime': return currentTime;
       case 'src': return src;
-      case 'videoWidth': return videoWidth;
-      case 'videoHeight': return videoHeight;
+      case 'width': return videoWidth;
+      case 'height': return videoHeight;
       default: return super.getBindingProperty(key);
     }
   }

--- a/packages/kraken_video_player/lib/video_element.dart
+++ b/packages/kraken_video_player/lib/video_element.dart
@@ -249,7 +249,7 @@ class VideoElement extends MediaElement {
   }
 
   void _bindingFastSeek(List args) {
-    fastSeek(castToType<double>(args[0]));
+    fastSeek(castToType<num>(args[0]).toDouble());
   }
 
   @override

--- a/packages/kraken_video_player/pubspec.yaml
+++ b/packages/kraken_video_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kraken_video_player
 description: Kraken video player plugin.
-version: 2.4.0
+version: 2.4.1
 homepage: https://openkraken.com
 
 environment:


### PR DESCRIPTION
The PR is aimed to fix the binding method call failed for video element.

The getBindingProperty returns an function for native side to perform invoking.